### PR TITLE
Fix MockRepository tests in CI

### DIFF
--- a/app/src/test/java/fi/jara/birdwatcher/mocks/MockObservationRepository.kt
+++ b/app/src/test/java/fi/jara/birdwatcher/mocks/MockObservationRepository.kt
@@ -18,7 +18,7 @@ class MockObservationRepository : ObservationRepository {
 
     override fun allObservations(sorting: ObservationSorting): LiveData<RepositoryLoadingStatus<List<Observation>>> {
         return MediatorLiveData<RepositoryLoadingStatus<List<Observation>>>().apply {
-            postValue(StatusLoading())
+            value = StatusLoading()
             GlobalScope.launch {
                 delay(5)
                 addSource(data) { status ->
@@ -30,9 +30,9 @@ class MockObservationRepository : ObservationRepository {
                             ObservationSorting.TimeDescending -> status.value.sortedByDescending { it.timestamp }
                         }
 
-                        postValue(StatusSuccess(sorted))
+                        value = StatusSuccess(sorted)
                     } else {
-                        postValue(status)
+                        value = status
                     }
                 }
             }
@@ -49,16 +49,16 @@ class MockObservationRepository : ObservationRepository {
                         is StatusSuccess -> {
                             val queried = status.value.find { it.id == id }
                             if (queried != null) {
-                                postValue(StatusSuccess(queried))
+                                value = StatusSuccess(queried)
                             } else {
-                                postValue(StatusEmpty())
+                                value = StatusEmpty()
                             }
                         }
                         is StatusError -> {
-                            postValue(StatusError(status.message))
+                            value = StatusError(status.message)
                         }
                         is StatusEmpty -> {
-                            postValue(StatusEmpty())
+                            value = StatusEmpty()
                         }
                         is StatusLoading -> {
                             // Loading is only for initial, and we manually post it already. This happening would be
@@ -97,22 +97,22 @@ class MockObservationRepository : ObservationRepository {
 class AlwaysFailingMockObservationRepository : ObservationRepository {
    override fun allObservations(sorting: ObservationSorting): LiveData<RepositoryLoadingStatus<List<Observation>>> {
         return MutableLiveData<RepositoryLoadingStatus<List<Observation>>>().apply {
-            postValue(StatusLoading())
+            value = StatusLoading()
 
             GlobalScope.launch {
                 delay(5)
-                postValue(StatusError(MOCK_OBSERVATION_REPOSITORY_ERROR_MESSAGE))
+                value = StatusError(MOCK_OBSERVATION_REPOSITORY_ERROR_MESSAGE)
             }
         }
     }
 
     override fun singleObservation(id: Long): LiveData<RepositoryLoadingStatus<Observation>> {
         return MutableLiveData<RepositoryLoadingStatus<Observation>>().apply {
-            postValue(StatusLoading())
+            value = StatusLoading()
 
             GlobalScope.launch {
                 delay(5)
-                postValue(StatusError(MOCK_OBSERVATION_REPOSITORY_ERROR_MESSAGE))
+                value = StatusError(MOCK_OBSERVATION_REPOSITORY_ERROR_MESSAGE)
             }
         }
     }

--- a/app/src/test/java/fi/jara/birdwatcher/mocks/MockObservationRepository.kt
+++ b/app/src/test/java/fi/jara/birdwatcher/mocks/MockObservationRepository.kt
@@ -1,7 +1,6 @@
 package fi.jara.birdwatcher.mocks
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import fi.jara.birdwatcher.data.*
 import fi.jara.birdwatcher.observations.Observation
@@ -10,85 +9,17 @@ import kotlinx.coroutines.*
 
 // Google doesn't provide a way to test Room databases on non-device tests
 // https://developer.android.com/training/data-storage/room/testing-db
-class MockObservationRepository : ObservationRepository {
-    private val data = MutableLiveData<RepositoryLoadingStatus<List<Observation>>>().apply { value = StatusEmpty() }
 
-    override fun allObservations(sorting: ObservationSorting): LiveData<RepositoryLoadingStatus<List<Observation>>> {
-        return MediatorLiveData<RepositoryLoadingStatus<List<Observation>>>().apply {
-            value = StatusLoading()
-            GlobalScope.launch(Dispatchers.IO) {
-                delay(8)
-                addSource(data) { status ->
-                    if (status is StatusSuccess) {
-                        val sorted = when (sorting) {
-                            ObservationSorting.NameAscending -> status.value.sortedBy { it.species }
-                            ObservationSorting.NameDescending -> status.value.sortedByDescending { it.species }
-                            ObservationSorting.TimeAscending -> status.value.sortedBy { it.timestamp }
-                            ObservationSorting.TimeDescending -> status.value.sortedByDescending { it.timestamp }
-                        }
+class MockObservationRepository: ObservationRepository {
+    val allObservationsLiveData = MutableLiveData<RepositoryLoadingStatus<List<Observation>>>()
+    val singleObservationLiveData = MutableLiveData<RepositoryLoadingStatus<Observation>>()
+    var addObservationReturnValue: RepositoryLoadingStatus<Observation>? = null
 
-                        value = StatusSuccess(sorted)
-                    } else {
-                        value = status
-                    }
-                }
-            }
-        }
-    }
+    override fun allObservations(sorting: ObservationSorting): LiveData<RepositoryLoadingStatus<List<Observation>>> = allObservationsLiveData
 
-    override fun singleObservation(id: Long): LiveData<RepositoryLoadingStatus<Observation>> {
-        return MediatorLiveData<RepositoryLoadingStatus<Observation>>().apply {
-            postValue(StatusLoading())
-            GlobalScope.launch(Dispatchers.IO) {
-                delay(8)
-                addSource(data) { status ->
-                    when (status) {
-                        is StatusSuccess -> {
-                            val queried = status.value.find { it.id == id }
-                            if (queried != null) {
-                                value = StatusSuccess(queried)
-                            } else {
-                                value = StatusEmpty()
-                            }
-                        }
-                        is StatusError -> {
-                            value = StatusError(status.message)
-                        }
-                        is StatusEmpty -> {
-                            value = StatusEmpty()
-                        }
-                        is StatusLoading -> {
-                            // Loading is only for initial, and we manually post it already. This happening would be
-                            // failure in mocking logic
-                        }
-                    }
-                }
-            }
-        }
-    }
+    override fun singleObservation(id: Long): LiveData<RepositoryLoadingStatus<Observation>> = singleObservationLiveData
 
-    override suspend fun addObservation(observationData: NewObservationData): RepositoryLoadingStatus<Observation> {
-        val curData = data.value
-        val prevs = if (curData is StatusSuccess) {
-            curData.value
-        } else {
-            emptyList()
-        }
-
-        val newId = (prevs.lastOrNull()?.id ?: 0) + 1
-        val observationModel = Observation(
-            newId,
-            observationData.species,
-            observationData.timestamp,
-            observationData.location,
-            observationData.rarity,
-            observationData.imageName,
-            observationData.description
-        )
-
-        data.value = StatusSuccess(prevs + observationModel)
-        return StatusSuccess(observationModel)
-    }
+    override suspend fun addObservation(observationData: NewObservationData) = addObservationReturnValue ?: throw IllegalStateException("Set return value for addObservation before calling it")
 }
 
 class AlwaysFailingMockObservationRepository : ObservationRepository {

--- a/app/src/test/java/fi/jara/birdwatcher/mocks/MockObservationRepository.kt
+++ b/app/src/test/java/fi/jara/birdwatcher/mocks/MockObservationRepository.kt
@@ -3,13 +3,10 @@ package fi.jara.birdwatcher.mocks
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
-import fi.jara.birdwatcher.common.NotFound
 import fi.jara.birdwatcher.data.*
 import fi.jara.birdwatcher.observations.Observation
 import fi.jara.birdwatcher.observations.ObservationSorting
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 
 // Google doesn't provide a way to test Room databases on non-device tests
 // https://developer.android.com/training/data-storage/room/testing-db
@@ -19,8 +16,8 @@ class MockObservationRepository : ObservationRepository {
     override fun allObservations(sorting: ObservationSorting): LiveData<RepositoryLoadingStatus<List<Observation>>> {
         return MediatorLiveData<RepositoryLoadingStatus<List<Observation>>>().apply {
             value = StatusLoading()
-            GlobalScope.launch {
-                delay(5)
+            GlobalScope.launch(Dispatchers.IO) {
+                delay(8)
                 addSource(data) { status ->
                     if (status is StatusSuccess) {
                         val sorted = when (sorting) {
@@ -42,8 +39,8 @@ class MockObservationRepository : ObservationRepository {
     override fun singleObservation(id: Long): LiveData<RepositoryLoadingStatus<Observation>> {
         return MediatorLiveData<RepositoryLoadingStatus<Observation>>().apply {
             postValue(StatusLoading())
-            GlobalScope.launch {
-                delay(5)
+            GlobalScope.launch(Dispatchers.IO) {
+                delay(8)
                 addSource(data) { status ->
                     when (status) {
                         is StatusSuccess -> {
@@ -99,8 +96,8 @@ class AlwaysFailingMockObservationRepository : ObservationRepository {
         return MutableLiveData<RepositoryLoadingStatus<List<Observation>>>().apply {
             value = StatusLoading()
 
-            GlobalScope.launch {
-                delay(5)
+            GlobalScope.launch(Dispatchers.IO) {
+                delay(8)
                 value = StatusError(MOCK_OBSERVATION_REPOSITORY_ERROR_MESSAGE)
             }
         }
@@ -110,8 +107,8 @@ class AlwaysFailingMockObservationRepository : ObservationRepository {
         return MutableLiveData<RepositoryLoadingStatus<Observation>>().apply {
             value = StatusLoading()
 
-            GlobalScope.launch {
-                delay(5)
+            GlobalScope.launch(Dispatchers.IO) {
+                delay(8)
                 value = StatusError(MOCK_OBSERVATION_REPOSITORY_ERROR_MESSAGE)
             }
         }

--- a/app/src/test/java/fi/jara/birdwatcher/mocks/MockObservationRepository.kt
+++ b/app/src/test/java/fi/jara/birdwatcher/mocks/MockObservationRepository.kt
@@ -21,36 +21,3 @@ class MockObservationRepository: ObservationRepository {
 
     override suspend fun addObservation(observationData: NewObservationData) = addObservationReturnValue ?: throw IllegalStateException("Set return value for addObservation before calling it")
 }
-
-class AlwaysFailingMockObservationRepository : ObservationRepository {
-   override fun allObservations(sorting: ObservationSorting): LiveData<RepositoryLoadingStatus<List<Observation>>> {
-        return MutableLiveData<RepositoryLoadingStatus<List<Observation>>>().apply {
-            value = StatusLoading()
-
-            GlobalScope.launch(Dispatchers.IO) {
-                delay(8)
-                value = StatusError(MOCK_OBSERVATION_REPOSITORY_ERROR_MESSAGE)
-            }
-        }
-    }
-
-    override fun singleObservation(id: Long): LiveData<RepositoryLoadingStatus<Observation>> {
-        return MutableLiveData<RepositoryLoadingStatus<Observation>>().apply {
-            value = StatusLoading()
-
-            GlobalScope.launch(Dispatchers.IO) {
-                delay(8)
-                value = StatusError(MOCK_OBSERVATION_REPOSITORY_ERROR_MESSAGE)
-            }
-        }
-    }
-
-    override suspend fun addObservation(observationData: NewObservationData): RepositoryLoadingStatus<Observation> {
-        return StatusError(MOCK_OBSERVATION_REPOSITORY_ERROR_MESSAGE)
-    }
-
-    companion object {
-        const val MOCK_OBSERVATION_REPOSITORY_ERROR_MESSAGE =
-            "[AlwaysFailingMockObservationRepository]Error storing observation"
-    }
-}

--- a/app/src/test/java/fi/jara/birdwatcher/observations/InsertNewObservationUseCaseTests.kt
+++ b/app/src/test/java/fi/jara/birdwatcher/observations/InsertNewObservationUseCaseTests.kt
@@ -2,7 +2,9 @@ package fi.jara.birdwatcher.observations
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import fi.jara.birdwatcher.common.Coordinate
+import fi.jara.birdwatcher.data.StatusSuccess
 import fi.jara.birdwatcher.mocks.*
+import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.fail
@@ -43,20 +45,18 @@ class InsertNewObservationUseCaseTests {
         val useCase = succeedingUseCase
 
         runBlocking {
-            runBlocking {
-                useCase.execute(
-                    InsertNewObservationUseCaseParams(
-                        "",
-                        true,
-                        ObservationRarity.Rare,
-                        "There's no Albatrosses in Finland, right?",
-                        ByteArray(1000) { it.toByte() }
-                    ),
-                    { fail("Succeeded when needed to fail") },
-                    {
-                        assertEquals("Species name is empty", it)
-                    })
-            }
+            useCase.execute(
+                InsertNewObservationUseCaseParams(
+                    "",
+                    true,
+                    ObservationRarity.Rare,
+                    "There's no Albatrosses in Finland, right?",
+                    ByteArray(1000) { it.toByte() }
+                ),
+                { fail("Succeeded when needed to fail") },
+                {
+                    assertEquals("Species name is empty", it)
+                })
         }
     }
 
@@ -144,11 +144,15 @@ class InsertNewObservationUseCaseTests {
 
     // TODO: inspect setuping these with Dagger?
     private val succeedingUseCase: InsertNewObservationUseCase
-        get() = InsertNewObservationUseCase(
-            MockObservationRepository(),
-            MockLocationSource(Coordinate(60.0, 20.0)),
-            AlwaysSucceedingImageStrorage()
-        )
+        get() {
+            val repo = MockObservationRepository()
+            repo.addObservationReturnValue = StatusSuccess(mockk())
+            return InsertNewObservationUseCase(
+                repo,
+                MockLocationSource(Coordinate(60.0, 20.0)),
+                AlwaysSucceedingImageStrorage()
+            )
+        }
 
 
     private val repositoryFailingUseCase: InsertNewObservationUseCase

--- a/app/src/test/java/fi/jara/birdwatcher/observations/InsertNewObservationUseCaseTests.kt
+++ b/app/src/test/java/fi/jara/birdwatcher/observations/InsertNewObservationUseCaseTests.kt
@@ -2,6 +2,7 @@ package fi.jara.birdwatcher.observations
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import fi.jara.birdwatcher.common.Coordinate
+import fi.jara.birdwatcher.data.StatusError
 import fi.jara.birdwatcher.data.StatusSuccess
 import fi.jara.birdwatcher.mocks.*
 import io.mockk.mockk
@@ -137,7 +138,7 @@ class InsertNewObservationUseCaseTests {
                 ),
                 { fail("Succeeded when needed to fail") },
                 {
-                    assertEquals(AlwaysFailingMockObservationRepository.MOCK_OBSERVATION_REPOSITORY_ERROR_MESSAGE, it)
+                    assertEquals(repositoryErrorMessage, it)
                 })
         }
     }
@@ -156,11 +157,15 @@ class InsertNewObservationUseCaseTests {
 
 
     private val repositoryFailingUseCase: InsertNewObservationUseCase
-        get() = InsertNewObservationUseCase(
-            AlwaysFailingMockObservationRepository(),
-            MockLocationSource(Coordinate(60.0, 20.0)),
-            AlwaysSucceedingImageStrorage()
-        )
+        get() {
+            val repo = MockObservationRepository()
+            repo.addObservationReturnValue = StatusError(repositoryErrorMessage)
+            return InsertNewObservationUseCase(
+                repo,
+                MockLocationSource(Coordinate(60.0, 20.0)),
+                AlwaysSucceedingImageStrorage()
+            )
+        }
 
     private val locationFailingUseCase: InsertNewObservationUseCase
         get() = InsertNewObservationUseCase(
@@ -175,4 +180,6 @@ class InsertNewObservationUseCaseTests {
             MockLocationSource(Coordinate(60.0, 20.0)),
             AlwaysFailingImageStorage()
         )
+
+    private val repositoryErrorMessage = "Error message from repository"
 }

--- a/app/src/test/java/fi/jara/birdwatcher/observations/ObserveAllObservationsUseCaseTests.kt
+++ b/app/src/test/java/fi/jara/birdwatcher/observations/ObserveAllObservationsUseCaseTests.kt
@@ -17,7 +17,6 @@ import org.junit.rules.TestRule
 import java.util.*
 import java.util.concurrent.TimeUnit
 
-@Ignore("The Mock repository observing is flaky in CI")
 class ObserveAllObservationsUseCaseTests {
     // Needed for LiveData
     @Rule

--- a/app/src/test/java/fi/jara/birdwatcher/observations/ObserveAllObservationsUseCaseTests.kt
+++ b/app/src/test/java/fi/jara/birdwatcher/observations/ObserveAllObservationsUseCaseTests.kt
@@ -5,12 +5,12 @@ import com.jraska.livedata.test
 import fi.jara.birdwatcher.common.LoadingInitial
 import fi.jara.birdwatcher.common.NotFound
 import fi.jara.birdwatcher.common.ValueFound
-import fi.jara.birdwatcher.data.NewObservationData
+import fi.jara.birdwatcher.data.StatusEmpty
+import fi.jara.birdwatcher.data.StatusLoading
+import fi.jara.birdwatcher.data.StatusSuccess
 import fi.jara.birdwatcher.mocks.AlwaysFailingMockObservationRepository
 import fi.jara.birdwatcher.mocks.MockObservationRepository
-import kotlinx.coroutines.runBlocking
 import org.junit.Assert.*
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
@@ -25,11 +25,14 @@ class ObserveAllObservationsUseCaseTests {
 
     @Test
     fun `emits loading and empty on no results`() {
-        val (_, useCase) = succeedingUseCase
+        val (repo, useCase) = succeedingUseCase
+        repo.allObservationsLiveData.value = StatusLoading()
 
-        val liveData = useCase.execute(ObservationSorting.TimeDescending).test().awaitNextValue(1, TimeUnit.SECONDS) // goes from loading to empty
+        val liveData = useCase.execute(ObservationSorting.TimeDescending).test()
+
+        repo.allObservationsLiveData.value = StatusEmpty()
+
         val history = liveData.valueHistory()
-
         assertEquals(2, history.size)
         assert(history[0].result is LoadingInitial)
         assert(history[1].result is NotFound)
@@ -38,28 +41,36 @@ class ObserveAllObservationsUseCaseTests {
     @Test
     fun `emits loading and value when observations exits`() {
         val (repo, useCase) = succeedingUseCase
+        repo.allObservationsLiveData.value = StatusLoading()
 
-        runBlocking {
-            repo.addObservation(NewObservationData("Albatross", Date(1000), null, ObservationRarity.Rare, null, null))
-            repo.addObservation(NewObservationData("Eagle", Date(2000), null, ObservationRarity.ExtremelyRare, null, null))
-        }
+        val liveData = useCase.execute(ObservationSorting.TimeDescending).test()
 
-        useCase.execute(ObservationSorting.TimeDescending).test().awaitNextValue(1, TimeUnit.SECONDS).assertValue { it.result is ValueFound }
+        repo.allObservationsLiveData.value = StatusSuccess(listOf(Observation(1, "Albatross", Date(1000), null, ObservationRarity.Rare, null, null)))
+
+        val history = liveData.valueHistory()
+        assertEquals(2, history.size)
+        assert(history[0].result is LoadingInitial)
+        assert(history[1].result is ValueFound)
     }
 
     @Test
     fun `emits new values when added to repository`() {
-
         val (repo, useCase) = succeedingUseCase
+        repo.allObservationsLiveData.value = StatusLoading()
 
-        val liveData = useCase.execute(ObservationSorting.TimeDescending).test().awaitNextValue(1, TimeUnit.SECONDS) // goes from loading to empty
+        val liveData = useCase.execute(ObservationSorting.TimeDescending).test()
 
-        runBlocking {
-            repo.addObservation(NewObservationData("Albatross", Date(1000), null, ObservationRarity.Rare, null, null))
-            repo.addObservation(NewObservationData("Eagle", Date(2000), null, ObservationRarity.ExtremelyRare, null, null))
-        }
+        repo.allObservationsLiveData.value = StatusSuccess(listOf(Observation(1, "Albatross", Date(1000), null, ObservationRarity.Rare, null, null)))
+        repo.allObservationsLiveData.value = StatusSuccess(listOf(
+            Observation(1, "Albatross", Date(1000), null, ObservationRarity.Rare, null, null),
+            Observation(2, "Eagle", Date(2000), null, ObservationRarity.Rare, null, null))
+        )
 
-        liveData.assertHistorySize(4) // loading, empty, 1 observation, 2 observations
+        val history = liveData.valueHistory()
+        assertEquals(3, history.size)
+        assert(history[0].result is LoadingInitial)
+        assert(history[1].result is ValueFound)
+        assert(history[2].result is ValueFound)
     }
 
     @Test

--- a/app/src/test/java/fi/jara/birdwatcher/observations/ObserveSingleObservationsUseCaseTests.kt
+++ b/app/src/test/java/fi/jara/birdwatcher/observations/ObserveSingleObservationsUseCaseTests.kt
@@ -17,8 +17,6 @@ import org.junit.rules.TestRule
 import java.util.*
 import java.util.concurrent.TimeUnit
 
-
-@Ignore("The Mock repository observing is flaky in CI")
 class ObserveSingleObservationsUseCaseTests {
     // Needed for LiveData
     @Rule


### PR DESCRIPTION
Using MutableLiveData postValue worked a bit differently on Bitrise than on local Mac, causing tests to be flaky in CI when they always passed locally. Swap to using setValue in MockObservationRepository to fix the flakyness, and re-enable the tests.